### PR TITLE
Merge bug/fix-item-respawn-manager-behaviour-after-respawn

### DIFF
--- a/src/wesenGemaMod/Extensions/ItemReset/PlayerItemRespawnManager.lua
+++ b/src/wesenGemaMod/Extensions/ItemReset/PlayerItemRespawnManager.lua
@@ -84,6 +84,7 @@ function PlayerItemRespawnManager:cancelAllItemRespawns()
   for _, itemRespawnTimer in pairs(self.itemRespawnTimers) do
     itemRespawnTimer:cancel()
   end
+  self.itemRespawnTimers = {}
 end
 
 ---
@@ -95,6 +96,8 @@ function PlayerItemRespawnManager:respawnAllItems()
     self:respawnItem(itemId)
     itemRespawnTimer:cancel()
   end
+
+  self.itemRespawnTimers = {}
 
 end
 


### PR DESCRIPTION
# Reproduce bug

1. Pick up an item
2. Respawn before the item is respawned
3. Let a different player pick up the same item

:arrow_right: The item will not respawn until you respawn again

# Fix
Cleared the list of  respawn Timer's when all of them are cancelled at once.

Problem was that the `PlayerItemRespawnManager.itemRespawnTimers` list still contained the old cancelled Timer's, and when `PlayerItemRespawnManager:hasPendingRespawnForItem()` was called to check if a pickup must be respawned for a player after another one picked it up, it would see that there already is a (wrong) respawn Timer for the given item and say "yes, there is a respawn Timer that will respawn the item, do not instantly respawn the item for the player".  