### PR TITLE
Merge feature/add-score-attempt-compare-times

### DIFF
--- a/src/config/colors.cfg
+++ b/src/config/colors.cfg
@@ -27,12 +27,13 @@ mapTopInfo=D
 mapTopRank=T
 mapTopNumberOfRecords=N
 
-mapRecordRank=T
+mapRecordRank=9
+mapRecordCurrentRank=M
 mapRecordName=H
 mapRecordTime=M
 mapRecordInfo=J
 mapRecordTimeStamp=X
-totalNumberOfMapScores=4
+totalNumberOfMapScores=9
 
 scoreRecordTied=Q
 scoreRecordSlower=4
@@ -43,15 +44,17 @@ serverTopInfo=P
 serverTopRank=T
 serverTopNumberOfRecords=2
 
-serverScoreRank=T
+serverScoreRank=9
+serverScoreCurrentRank=M
 serverScoreName=H
 serverScorePoints=M
 serverScoreNumberOfBestTimes=2
-serverScoreNumberOfCompletedMaps=5
+serverScoreNumberOfCompletedMaps=M
+serverScoreTotalNumberOfMaps=5
 serverScoreNumberOfBestTimesText=4
 serverScoreNumberOfCompletedMapsText=4
 serverScoreInfo=Q
-totalNumberOfServerScores=4
+totalNumberOfServerScores=9
 
 playerTextDefault=E
 playerSayTextColon=5

--- a/src/config/colors.cfg
+++ b/src/config/colors.cfg
@@ -35,6 +35,10 @@ mapRecordInfo=J
 mapRecordTimeStamp=X
 totalNumberOfMapScores=9
 
+mapScoreTimeDigit=M
+mapScoreTimeUnit=N
+mapScoreTimeText=J
+
 scoreRecordTied=Q
 scoreRecordSlower=4
 

--- a/src/config/colors.cfg
+++ b/src/config/colors.cfg
@@ -39,6 +39,10 @@ mapScoreTimeDigit=M
 mapScoreTimeUnit=N
 mapScoreTimeText=J
 
+mapScoreDifferenceTimeDigit=Q
+mapScoreDifferenceTimeUnit=T
+mapScoreDifferenceTimeText=J
+
 scoreRecordTied=Q
 scoreRecordSlower=4
 

--- a/src/config/config.lua
+++ b/src/config/config.lua
@@ -23,6 +23,7 @@ return {
     logger = { isEnabled = true, isDebugEnabled = false }
   },
   databaseKeepAliveQueryInterval = 30 * 60 * 1000,
+  databaseKeepAliveQuery = "SELECT COUNT(`maps`.`id`) FROM `maps`;",
 
   ClientOutputFactory = {
     fontConfigFileName = "FontDefault",

--- a/src/config/templates/Commands/MapScore/MapScore.template
+++ b/src/config/templates/Commands/MapScore/MapScore.template
@@ -34,10 +34,11 @@
   {* colors.mapRecordInfo *}
   <whitespace>
   (
-    Rank
-    {* colors.mapRecordRank *} {* mapRecord:getRank() *}
+    {* colors.mapRecordRank *}Rank
+    {* colors.mapRecordCurrentRank *} {* mapRecord:getRank() *}
     {* colors.mapRecordInfo *}/
     {* colors.totalNumberOfMapScores *}{* numberOfMapScores *}
+    {* colors.mapRecordInfo *}
   )
 
   {* colors.mapRecordInfo *} with

--- a/src/config/templates/Commands/ServerScore/ServerScore.template
+++ b/src/config/templates/Commands/ServerScore/ServerScore.template
@@ -28,10 +28,11 @@
   {* colors.serverScoreInfo *}
   <whitespace>
   (
-    Rank
-    {* colors.serverScoreRank *} {* serverScore:getRank() *}
+    {* colors.serverScoreRank *}Rank
+    {* colors.serverScoreCurrentRank *} {* serverScore:getRank() *}
     {* colors.serverScoreInfo *}/
     {* colors.totalNumberOfServerScores *}{* numberOfServerScores *}
+    {* colors.serverScoreInfo *}
     ,
     <whitespace>
 

--- a/src/config/templates/ServerScoreManager/ServerTop/ServerScore/NumberOfScores.template
+++ b/src/config/templates/ServerScoreManager/ServerTop/ServerScore/NumberOfScores.template
@@ -18,7 +18,7 @@
 {* colors.serverScoreNumberOfCompletedMaps *}
 {* string.format("%0" .. maxMapsCompletedLength .. "d", serverScore:getNumberOfMapRecords()) *}
 {* colors.serverScoreInfo *}/
-{* colors.serverScoreNumberOfCompletedMaps *}{* numberOfGemaMaps *}
+{* colors.serverScoreTotalNumberOfMaps *}{* numberOfGemaMaps *}
 <whitespace>
 {* colors.serverScoreInfo *}(
 {* colors.serverScoreNumberOfCompletedMaps *}{* string.format("%05.02f", (serverScore:getNumberOfMapRecords() / numberOfGemaMaps) * 100) *}%

--- a/src/config/templates/TableTemplate/MapRecord/MapRecordScore.template
+++ b/src/config/templates/TableTemplate/MapRecord/MapRecordScore.template
@@ -5,6 +5,8 @@
  # @tparam string[] colors The list of colors
  # @tparam TimeFormatter timeFormatter The time formatter
  # @tparam MapRecord mapRecord The map record
+ # @tparam int differenceToOwnBestTime The difference to the best time of the player who scored
+ # @tparam int differenceToBestTime The difference to the best time of the map
  #}
 
 {[
@@ -23,7 +25,9 @@
     { getAbsoluteTemplatePath = getAbsoluteTemplatePath,
       colors = colors,
       timeFormatter = timeFormatter,
-      mapRecord = mapRecord
+      mapRecord = mapRecord,
+      differenceToOwnBestTime = differenceToOwnBestTime,
+      differenceToBestTime = differenceToBestTime
     }
   ]}
 {% end %}
@@ -33,7 +37,9 @@ _______________________________________________;
   {[
     getAbsoluteTemplatePath("TextTemplate/MapRecord/MapRecordNewBestTime"),
     { getAbsoluteTemplatePath = getAbsoluteTemplatePath,
-      colors = colors
+      timeFormatter = timeFormatter,
+      colors = colors,
+      differenceToBestTime = differenceToBestTime
     }
   ]}
 

--- a/src/config/templates/TextTemplate/MapRecord/AdditionalScoreTimeDifferences.template
+++ b/src/config/templates/TextTemplate/MapRecord/AdditionalScoreTimeDifferences.template
@@ -1,0 +1,62 @@
+{#
+ # Prints the additional score time differences message.
+ # This includes the difference to the next rank and the difference to the first rank.
+ #
+ # @tparam function getAbsoluteTemplatePath The function to fetch absolute template paths
+ # @tparam TimeFormatter timeFormatter The time formatter
+ # @tparam string[] colors The list of colors
+ # @tparam int nextRank The next rank that the player can reach
+ # @tparam int differenceToNextRank The difference to the next rank's time (nil if the next rank is 1)
+ # @tparam int differenceToFirstRank The difference to the best time of the map
+ #}
+
+{# Difference to next rank #}
+{% if (differenceToNextRank ~= nil) then %}
+
+  {[
+    getAbsoluteTemplatePath("TextTemplate/MapRecord/ScoreTimeDifference"),
+    {
+      colors = colors,
+      timeFormatter = timeFormatter,
+      differenceInMilliseconds = differenceToNextRank
+    }
+  ]}
+
+  {* colors.mapRecordInfo *}
+  <whitespace>
+  from
+  <whitespace>
+  {* colors.mapRecordRank *}
+  {[
+    getAbsoluteTemplatePath("TextTemplate/MapRecord/Rank"),
+    { rank = nextRank }
+  ]}
+
+  {* colors.mapRecordInfo *} (next)
+
+  <whitespace>
+  /
+  <whitespace>
+
+{% end %}
+
+
+{# Difference to first rank #}
+{[
+  getAbsoluteTemplatePath("TextTemplate/MapRecord/ScoreTimeDifference"),
+  {
+    colors = colors,
+    timeFormatter = timeFormatter,
+    differenceInMilliseconds = differenceToFirstRank
+  }
+]}
+
+{* colors.mapRecordInfo *}
+<whitespace>
+from
+<whitespace>
+{* colors.mapRecordRank *}
+{[
+  getAbsoluteTemplatePath("TextTemplate/MapRecord/Rank"),
+  { rank = 1 }
+]}

--- a/src/config/templates/TextTemplate/MapRecord/MapRecordNewBestTime.template
+++ b/src/config/templates/TextTemplate/MapRecord/MapRecordNewBestTime.template
@@ -2,7 +2,31 @@
  # Prints the "new best time" message.
  # The result is "***** NEW BEST TIME *****".
  #
+ # @tparam function getAbsoluteTemplatePath The function to fetch absolute template paths
+ # @tparam TimeFormatter timeFormatter The time formatter
  # @tparam string[] colors The list of colors
+ # @tparam int differenceToBestTime The difference to the best time of the map
  #}
 
-{* colors.newBestTimeString *}***** NEW BEST TIME *****
+{% if (differenceToBestTime == nil) then %}
+  {# It's the first time that someone scores on this map, so no comparison time is available #}
+  {* colors.newBestTimeString *}***** NEW BEST TIME *****
+
+{% else %}
+  {* colors.newBestTimeString *}*****
+  <whitespace>
+  BEST TIME BEATEN BY
+  <whitespace>
+
+  {[
+    getAbsoluteTemplatePath("TextTemplate/MapRecord/ScoreTimeDifference"),
+    {
+      colors = colors,
+      timeFormatter = timeFormatter,
+      differenceInMilliseconds = differenceToBestTime
+    }
+  ]}
+
+  <whitespace>
+  {* colors.newBestTimeString *}*****
+{% end %}

--- a/src/config/templates/TextTemplate/MapRecord/MapRecordScoreRank.template
+++ b/src/config/templates/TextTemplate/MapRecord/MapRecordScoreRank.template
@@ -2,8 +2,12 @@
  # Prints the score record rank if the record is a new personal best time or a "record tied" or "record
  # slower message" in the other cases.
  #
+ # @tparam function getAbsoluteTemplatePath The function to fetch absolute template paths
+ # @tparam TimeFormatter timeFormatter The time formatter
  # @tparam string[] colors The list of colors
  # @tparam MapRecord mapRecord The map record
+ # @tparam int differenceToOwnBestTime The difference to the best time of the player who scored
+ # @tparam int differenceToBestTime The difference to the best time of the map
  #}
 
 {% local mapRecordList = mapRecord:getParentMapRecordList(); %}
@@ -23,11 +27,26 @@
   {% end %}
 
   {(lua/config/templates/TextTemplate/MapRecord/MapRecordScoreRankPersonalBest.template,
-    { colors = colors, mapRecord = mapRecord, numberOfRecords = numberOfRecords }
+    {
+      getAbsoluteTemplatePath = getAbsoluteTemplatePath,
+      timeFormatter = timeFormatter,
+      colors = colors,
+      mapRecord = mapRecord,
+      numberOfRecords = numberOfRecords,
+      differenceToOwnBestTime = differenceToOwnBestTime,
+      differenceToBestTime = differenceToBestTime
+    }
   )}
 
 {% elseif (currentRecord:getMilliseconds() == mapRecord:getMilliseconds()) then %}
   {(lua/config/templates/TextTemplate/MapRecord/MapRecordScoreRankRecordTied.template, { colors = colors })}
 {% else %}
-  {(lua/config/templates/TextTemplate/MapRecord/MapRecordScoreRankRecordSlower.template, { colors = colors })}
+  {(lua/config/templates/TextTemplate/MapRecord/MapRecordScoreRankRecordSlower.template,
+    {
+      getAbsoluteTemplatePath = getAbsoluteTemplatePath,
+      timeFormatter = timeFormatter,
+      colors = colors,
+      differenceToOwnBestTime = differenceToOwnBestTime
+    }
+  )}
 {% end %}

--- a/src/config/templates/TextTemplate/MapRecord/MapRecordScoreRankPersonalBest.template
+++ b/src/config/templates/TextTemplate/MapRecord/MapRecordScoreRankPersonalBest.template
@@ -7,5 +7,11 @@
  # @tparam int numberOfRecords The total number of records
  #}
 
-{* colors.mapRecordRank *}
-(Rank {* mapRecord:getRank() *} of {* numberOfRecords *})
+{* colors.mapRecordInfo *}
+(
+  {* colors.mapRecordRank *}Rank
+  {* colors.mapRecordCurrentRank *} {* mapRecord:getRank() *}
+  {* colors.mapRecordInfo *}/
+  {* colors.totalNumberOfMapScores *}{* numberOfRecords *}
+  {* colors.mapRecordInfo *}
+)

--- a/src/config/templates/TextTemplate/MapRecord/MapRecordScoreRankPersonalBest.template
+++ b/src/config/templates/TextTemplate/MapRecord/MapRecordScoreRankPersonalBest.template
@@ -2,13 +2,35 @@
  # Prints the score rank for a map record.
  # The result is "Rank x of y".
  #
+ # @tparam function getAbsoluteTemplatePath The function to fetch absolute template paths
+ # @tparam TimeFormatter timeFormatter The time formatter
  # @tparam string[] colors The list of colors
  # @tparam MapRecord mapRecord The map record
  # @tparam int numberOfRecords The total number of records
+ # @tparam int differenceToOwnBestTime The difference to the best time of the player who scored
+ # @tparam int differenceToBestTime The difference to the best time of the map
  #}
 
 {* colors.mapRecordInfo *}
 (
+  {% if (differenceToOwnBestTime ~= nil and differenceToOwnBestTime ~= differenceToBestTime) then %}
+    {* colors.newBestTimeString *}
+    Improved by
+    <whitespace>
+    {[
+      getAbsoluteTemplatePath("TextTemplate/MapRecord/ScoreTimeDifference"),
+      {
+        colors = colors,
+        timeFormatter = timeFormatter,
+        differenceInMilliseconds = differenceToOwnBestTime
+      }
+    ]}
+
+    {* colors.mapRecordInfo *}
+    ,
+    <whitespace>
+  {% end %}
+
   {* colors.mapRecordRank *}Rank
   {* colors.mapRecordCurrentRank *} {* mapRecord:getRank() *}
   {* colors.mapRecordInfo *}/

--- a/src/config/templates/TextTemplate/MapRecord/MapRecordScoreRankRecordSlower.template
+++ b/src/config/templates/TextTemplate/MapRecord/MapRecordScoreRankRecordSlower.template
@@ -1,7 +1,23 @@
 {#
  # Prints the "record slower" message.
  #
+ # @tparam function getAbsoluteTemplatePath The function to fetch absolute template paths
+ # @tparam TimeFormatter timeFormatter The time formatter
  # @tparam string[] colors The list of colors
+ # @tparam int differenceToOwnBestTime The difference to the best time of the player who scored
  #}
 
-{* colors.scoreRecordSlower *}(But has a better record)
+{* colors.mapRecordInfo *}
+(
+  {[
+    getAbsoluteTemplatePath("TextTemplate/MapRecord/ScoreTimeDifference"),
+    {
+      colors = colors,
+      timeFormatter = timeFormatter,
+      differenceInMilliseconds = differenceToOwnBestTime
+    }
+  ]}
+
+  {* colors.scoreRecordSlower *} slower than own best time
+  {* colors.mapRecordInfo *}
+)

--- a/src/config/templates/TextTemplate/MapRecord/MapRecordScoreRankRecordTied.template
+++ b/src/config/templates/TextTemplate/MapRecord/MapRecordScoreRankRecordTied.template
@@ -4,4 +4,4 @@
  # @tparam string[] colors The list of colors
  #}
 
-{* colors.scoreRecordTied *}(Tied current personal best record)
+{* colors.scoreRecordTied *}(Tied own best time)

--- a/src/config/templates/TextTemplate/MapRecord/MapRecordScoreTime.template
+++ b/src/config/templates/TextTemplate/MapRecord/MapRecordScoreTime.template
@@ -15,7 +15,7 @@
   { colors = colors, timeFormatter = timeFormatter, mapRecord = mapRecord }
 )}
 
-{* colors.mapRecordInfo *} minutes with
+{* colors.mapRecordInfo *} with
 
 <whitespace>
 {(lua/config/templates/TextTemplate/Player/PlayerTeamColor.template,

--- a/src/config/templates/TextTemplate/MapRecord/MapRecordTime.template
+++ b/src/config/templates/TextTemplate/MapRecord/MapRecordTime.template
@@ -9,7 +9,15 @@
 {% if (not mapRecord:getTimeString()) then %}
 
   {# There is no cached time string, generate one #}
-  {% local timeString = timeFormatter:generateTimeString(mapRecord:getMilliseconds(), "%02i:%02s,%03v"); %}
+  {% local timeString = timeFormatter:generateTimeString(
+       mapRecord:getMilliseconds(),
+       "-%02i- %02s- %03v-",
+       {
+         time = colors.mapScoreTimeDigit,
+         timeUnit = colors.mapScoreTimeUnit,
+         text = colors.mapScoreTimeText
+       }
+     ) %}
   {% mapRecord:setTimeString(timeString); %}
 
 {% end %}

--- a/src/config/templates/TextTemplate/MapRecord/Rank.template
+++ b/src/config/templates/TextTemplate/MapRecord/Rank.template
@@ -1,0 +1,15 @@
+{#
+ # Prints a map record rank.
+ #
+ # @tparam int rank The rank
+ #}
+
+{% if (rank == 1) then %}
+  1st
+{% elseif (rank == 2) then %}
+  2nd
+{% elseif (rank == 3) then %}
+  3rd
+{% else %}
+  {* rank *}th
+{% end %}

--- a/src/config/templates/TextTemplate/MapRecord/ScoreTimeDifference.template
+++ b/src/config/templates/TextTemplate/MapRecord/ScoreTimeDifference.template
@@ -1,0 +1,17 @@
+{#
+ # Prints a score time difference for a map record.
+ #
+ # @tparam string[] colors The list of colors
+ # @tparam TimeFormatter timeFormatter The time formatter
+ # @tparam int differenceInMilliseconds The score time difference in milliseconds
+ #}
+
+{* timeFormatter:generateTimeString(
+     differenceInMilliseconds,
+     "-%02i- %02s- %03v-",
+     {
+       time = colors.mapScoreDifferenceTimeDigit,
+       timeUnit = colors.mapScoreDifferenceTimeUnit,
+       text = colors.mapScoreDifferenceTimeText
+     }
+   ) *}

--- a/src/main.lua
+++ b/src/main.lua
@@ -36,7 +36,7 @@ local keepDatabaseConnectionAliveTimer = Timer(
   Timer.TYPE_PERIODIC,
   config.databaseKeepAliveQueryInterval or 30 * 60 * 1000,
   function()
-    LuaORM_API.ORM:getDatabaseConnection():execute("DO 0;")
+    LuaORM_API.ORM:getDatabaseConnection():execute(config.databaseKeepAliveQuery or "SELECT COUNT(`maps`.`id`) FROM `maps`;")
   end
 )
 

--- a/src/wesenGemaMod/Output/TimeFormatter.lua
+++ b/src/wesenGemaMod/Output/TimeFormatter.lua
@@ -1,56 +1,84 @@
 ---
 -- @author wesen
--- @copyright 2018 wesen <wesen-ac@web.de>
+-- @copyright 2018-2021 wesen <wesen-ac@web.de>
 -- @release 0.1
 -- @license MIT
 --
 
+local Object = require "classic"
+
 ---
--- Handles converting times in milliseconds to readable formats.
+-- Handles converting of times in milliseconds to readable formats.
 --
 -- @type TimeFormatter
 --
-local TimeFormatter = setmetatable({}, {});
+local TimeFormatter = Object:extend()
+
+-- The available trimming mode for leading time parts whose value is 0
+TimeFormatter.LEADING_ZERO_TIME_PART_TRIMMING_NONE = 1
+TimeFormatter.LEADING_ZERO_TIME_PART_TRIMMING_UNTIL_FIRST_NON_WHITESPACE = 1
+
+---
+-- The custom time unit names to use when a custom time unit name is requested
+--
+-- This table may have one or more of the following fields:
+-- {
+--   minutes = <minutes time unit name>,
+--   seconds = <seconds time unit name>,
+--   milliseconds = <milliseconds time unit name>
+-- }
+--
+-- @tfield string[] customTimeUnitNames
+--
+TimeFormatter.customTimeUnitNames = nil
 
 ---
 -- The minutes part of the last converted milliseconds
 --
 -- @tfield int minutes
 --
-TimeFormatter.minutes = nil;
+TimeFormatter.minutes = nil
 
 ---
 -- The seconds part of the last converted milliseconds
 --
 -- @tfield int seconds
 --
-TimeFormatter.seconds = nil;
+TimeFormatter.seconds = nil
 
 ---
 -- The remaining milliseconds part of the last converted milliseconds
 --
 -- @tfield int milliseconds
 --
-TimeFormatter.milliseconds = nil;
+TimeFormatter.milliseconds = nil
+
+---
+-- The current trimming mode for leading time parts whose value is 0
+--
+-- @tfield int leadingZeroTimePartTrimmingMode
+--
+TimeFormatter.leadingZeroTimePartTrimmingMode = nil
+
+---
+-- Stores whether a non zero time part was found during the current time string generation
+--
+-- @tfield bool nonZeroTimePartFound
+--
+TimeFormatter.nonZeroTimePartFound = nil
 
 
 ---
--- TimePrinter constructor.
+-- TimeFormatter constructor.
 --
--- @treturn TimePrinter The TimePrinter instance
+-- @tparam string[] _customTimeUnitNames The custom time unit names to use (optional)
 --
-function TimeFormatter:__construct()
-
-  local instance = setmetatable({}, {__index = TimeFormatter});
-  instance.minutes = 0;
-  instance.seconds = 0;
-  instance.milliseconds = 0;
-
-  return instance;
-
+function TimeFormatter:new(_customTimeUnitNames)
+  self.customTimeUnitNames = _customTimeUnitNames or {}
+  self.minutes = 0
+  self.seconds = 0
+  self.milliseconds = 0
 end
-
-getmetatable(TimeFormatter).__call = TimeFormatter.__construct;
 
 
 -- Public Methods
@@ -58,30 +86,74 @@ getmetatable(TimeFormatter).__call = TimeFormatter.__construct;
 ---
 -- Returns a time in milliseconds in a custom format.
 --
--- Available format specifiers are:
+-- The following format string configurations are available:
+--
+-- "-" At the beginning: Cut off every leading text until the first non zero time part or the first non whitespace character
+--
+-- The following time format specifiers are available:
 --
 -- %i: Minutes
 -- %s: Seconds
 -- %v: Milliseconds
+-- %T: Total time string time unit (Largest non zero time unit)
 --
--- You can also specify automatic padding by adding <pad symbol><total number of symbols> between
--- the % and the format specifier id, e.g. "%02i" will print "4" as "04"
+-- You can add a number of padding zeros between "%" and <format specifier type identifier> to pad
+-- the digits by x zeros, e.g. "%02i" will print "4" as "04".
+--
+-- You can also configure the time unit type with the character after the format specifier type identifier:
+--
+-- "-": Abbreviated time unit name for that time unit
+-- "+": Full time unit name for that time unit
+-- "*": Custom time unit name for that time unit
+-- <anything else | nothing>: No time unit name is shown
+--
+-- Numbers after the time unit type configure by how many whitespaces the time unit name will be separated
+-- from the time digits.
+--
+--
+-- The given colors list must have the following format:
+-- {
+--   text = <color>,
+--   time = <color>,
+--   timeUnit = <color>
+-- }
 --
 -- @tparam int _milliseconds The time in milliseconds
 -- @tparam string _format The format for the time
+-- @tparam string[] _colors The time colors
 --
--- @treturn string The record in the format "Minutes:Seconds,Milliseconds"
+-- @treturn string The formatted time string
 --
-function TimeFormatter:generateTimeString(_milliseconds, _format)
+function TimeFormatter:generateTimeString(_milliseconds, _format, _colors)
 
-  self:parseMilliseconds(_milliseconds);
+  self:parseMilliseconds(_milliseconds)
 
-  return _format:gsub(
-    "(%%.?%d?)(%a)",
-    function (_a, _b)
-      return self:getFormatSpecifierReplace(_a, _b);
+  local timeString = _format
+
+  -- Parse the leadingZeroTimePartTrimmingMode config
+  if (timeString:find("^%-") == 1) then
+    timeString = timeString:sub(2)
+    self.leadingZeroTimePartTrimmingMode = self.LEADING_ZERO_TIME_PART_TRIMMING_UNTIL_FIRST_NON_WHITESPACE
+  else
+    self.leadingZeroTimePartTrimmingMode = self.LEADING_ZERO_TIME_PART_TRIMMING_NONE
+  end
+
+  -- Parse and replace all format specifiers
+  self.nonZeroTimePartFound = false
+  timeString = timeString:gsub(
+    "%%(%d*)([isvT])([-+*]?)(%d*)",
+    function (...)
+      return self:generateFormatSpecifierReplaceText(_colors, ...)
     end
-  );
+  )
+
+  -- Remove leading whitespace
+  timeString = timeString:gsub("^ *", "")
+
+  -- Prepend the default text color
+  timeString = _colors["text"] .. timeString
+
+  return timeString
 
 end
 
@@ -96,33 +168,55 @@ end
 --
 function TimeFormatter:parseMilliseconds(_totalMilliseconds)
 
-  local milliseconds = math.fmod(_totalMilliseconds, 1000);
+  local milliseconds = math.fmod(_totalMilliseconds, 1000)
 
-  local totalSeconds = (_totalMilliseconds - milliseconds) / 1000;
-  local seconds = math.fmod(totalSeconds, 60);
+  local totalSeconds = (_totalMilliseconds - milliseconds) / 1000
+  local seconds = math.fmod(totalSeconds, 60)
 
-  local minutes = (totalSeconds - seconds) / 60;
+  local minutes = (totalSeconds - seconds) / 60
 
-  self.milliseconds = milliseconds;
-  self.seconds = seconds;
-  self.minutes = minutes;
+  self.milliseconds = milliseconds
+  self.seconds = seconds
+  self.minutes = minutes
 
 end
 
 ---
 -- Returns the replacement string for a format specifier.
 --
--- @tparam string _formatSpecifierPadding The format specifier padding (e.g. %02)
--- @tparam string _formatSpecifierId The format specifier id (e.g. "i", "s" or "v")
+-- @tparam string[] _colors The colors to use to colorize the time string
+-- @tparam string _formatSpecifierPadding The configured format specifier padding (e.g. "02")
+-- @tparam string _formatSpecifierId The format specifier id ("i", "s", "v" or "T")
+-- @tparam string _timeUnitType The time unit type ("+", "-", "*")
+-- @tparam string _timeUnitNamePadding The time unit name padding (e.g. "04")
 --
--- @treturn string|nil The replacement string or nil if no the format specifier id is invalid
+-- @treturn string The replacement string
 --
-function TimeFormatter:getFormatSpecifierReplace(_formatSpecifierPadding, _formatSpecifierId)
+function TimeFormatter:generateFormatSpecifierReplaceText(_colors, _formatSpecifierPadding, _formatSpecifierId, _timeUnitType, _timeUnitNamePadding)
 
-  local formatSpecifierValue = self:getFormatSpecifierValue(_formatSpecifierId);
-  if (formatSpecifierValue) then
-    return string.format(_formatSpecifierPadding .. "d", formatSpecifierValue);
+  local formatSpecifierValue = self:getFormatSpecifierValue(_formatSpecifierId)
+  if (formatSpecifierValue == nil) then
+    return ""
   end
+
+  if (formatSpecifierValue > 0) then
+    self.nonZeroTimePartFound = true
+  end
+
+  if (self.leadingZeroTimePartTrimmingMode == self.LEADING_ZERO_TIME_PART_TRIMMING_UNTIL_FIRST_NON_WHITESPACE) then
+    if (formatSpecifierValue == 0 and not self.nonZeroTimePartFound) then
+      return ""
+    end
+  end
+
+  local formatSpecifierPadding = tonumber(_formatSpecifierPadding) or 0
+  local timeUnitNamePadding = tonumber(_timeUnitNamePadding) or 0
+
+  return string.format(
+    _colors["time"] .. "%0" .. formatSpecifierPadding .. "d" .. _colors["timeUnit"] .. "% " .. timeUnitNamePadding .. "s" .. _colors["text"],
+    formatSpecifierValue,
+    self:getTimeUnitName(_formatSpecifierId, _timeUnitType)
+  )
 
 end
 
@@ -135,19 +229,78 @@ end
 --
 function TimeFormatter:getFormatSpecifierValue(_formatSpecifierId)
 
-  local formatSpecifierValue = nil;
+  local formatSpecifierValue = nil
 
   if (_formatSpecifierId == "i") then
-    formatSpecifierValue = self.minutes;
+    formatSpecifierValue = self.minutes
   elseif (_formatSpecifierId == "s") then
-    formatSpecifierValue = self.seconds;
+    formatSpecifierValue = self.seconds
   elseif (_formatSpecifierId == "v") then
-    formatSpecifierValue = self.milliseconds;
+    formatSpecifierValue = self.milliseconds
   end
 
-  return formatSpecifierValue;
+  return formatSpecifierValue
+
+end
+
+---
+-- Returns the time unit name for a given time unit type.
+--
+-- @tparam string _formatSpecifierId The format specifier ID
+-- @tparam string _timeUnitTypeId The time unit type ID
+--
+-- @treturn string The time unit name
+--
+function TimeFormatter:getTimeUnitName(_formatSpecifierId, _timeUnitTypeId)
+
+  local timeUnitName = ""
+  if (_formatSpecifierId == "i") then
+    -- Minutes
+    if (_timeUnitTypeId == "-") then
+      timeUnitName = "m"
+    elseif (_timeUnitTypeId == "+") then
+      timeUnitName = "minutes"
+    elseif (_timeUnitTypeId == "*") then
+      timeUnitName = self.customTimeUnitNames["minutes"] or ""
+    end
+
+  elseif (_formatSpecifierId == "s") then
+    -- Seconds
+    if (_timeUnitTypeId == "-") then
+      timeUnitName = "s"
+    elseif (_timeUnitTypeId == "+") then
+      timeUnitName = "seconds"
+    elseif (_timeUnitTypeId == "*") then
+      timeUnitName = self.customTimeUnitNames["seconds"] or ""
+    end
+
+  elseif (_formatSpecifierId == "v") then
+    -- Milliseconds
+    if (_timeUnitTypeId == "-") then
+      timeUnitName = "ms"
+    elseif (_timeUnitTypeId == "+") then
+      timeUnitName = "milliseconds"
+    elseif (_timeUnitTypeId == "*") then
+      timeUnitName = self.customTimeUnitNames["milliseconds"] or ""
+    end
+
+  elseif (_formatSpecifierId == "T") then
+    -- Largest non zero time unit
+    local largestTimeUnit
+    if (self.minutes > 0) then
+      largestTimeUnit = "i"
+    elseif (self.seconds > 0) then
+      largestTimeUnit = "s"
+    else
+      largestTimeUnit = "v"
+    end
+
+    timeUnitName = self:getTimeUnitName(largestTimeUnit, _timeUnitTypeId)
+  end
+
+  return timeUnitName
 
 end
 
 
-return TimeFormatter;
+return TimeFormatter

--- a/src/wesenGemaMod/ScoreAttemptManager/ScoreAttemptManager.lua
+++ b/src/wesenGemaMod/ScoreAttemptManager/ScoreAttemptManager.lua
@@ -173,6 +173,8 @@ function ScoreAttemptManager:registerRecord(scoreAttempt)
       differenceToFirstRank = differenceToFirstRank * -1
     end
   end
+
+  -- Print the score time and the comparison to the old personal best time to all players
   local output = Server.getInstance():getOutput()
   output:printTableTemplate(
     "TableTemplate/MapRecord/MapRecordScore",
@@ -183,6 +185,21 @@ function ScoreAttemptManager:registerRecord(scoreAttempt)
   )
 
   if (record:getIsValid()) then
+
+    if (nextRank >= 1) then
+
+      -- Print the comparison to the next and first rank only to the player who scored
+      output:printTextTemplate(
+        "TextTemplate/MapRecord/AdditionalScoreTimeDifferences",
+        {
+          nextRank = nextRank,
+          differenceToNextRank = differenceToNextRank,
+          differenceToFirstRank = differenceToFirstRank
+        },
+        scoreAttempt:getParentPlayer()
+      )
+    end
+
     mapTop:addRecord(record)
   end
 


### PR DESCRIPTION
Added a first version of score attempt compare times output which includes:

- A comparison to the own previous record (if one exists) (shown to all players)
- The comparison to the next and first rank (if existing) (shown only to the player who scored)

Fixes #92