### PR TITLE
Merge bug/fix-show-difference-if-distance-to-first-rank-was-halved

### DIFF
--- a/src/config/templates/GemaScoreManager/ScoreAttemptScoreOutput/NewBestMapScore.template
+++ b/src/config/templates/GemaScoreManager/ScoreAttemptScoreOutput/NewBestMapScore.template
@@ -25,7 +25,7 @@
     {
       colors = colors,
       timeFormatter = timeFormatter,
-      differenceInMilliseconds = differenceToBestTime
+      differenceInMilliseconds = differenceToBestTime * -1
     }
   ]}
 

--- a/src/config/templates/GemaScoreManager/ScoreAttemptScoreOutput/Status.template
+++ b/src/config/templates/GemaScoreManager/ScoreAttemptScoreOutput/Status.template
@@ -23,7 +23,7 @@
       colors = colors,
       mapScore = mapScore,
       totalNumberOfMapScores = totalNumberOfMapScores,
-      differenceToOwnBestTime = (differenceToOwnBestTime ~= nil and differenceToOwnBestTime * -1 or nil),
+      differenceToOwnBestTime = differenceToOwnBestTime,
       differenceToBestTime = differenceToBestTime
     }
   ]}

--- a/src/config/templates/GemaScoreManager/ScoreAttemptScoreOutput/Status/NewPersonalBest.template
+++ b/src/config/templates/GemaScoreManager/ScoreAttemptScoreOutput/Status/NewPersonalBest.template
@@ -15,7 +15,9 @@
 
 {* colors.mapRecordInfo *}
 (
-  {% if (differenceToOwnBestTime ~= nil and differenceToOwnBestTime ~= differenceToBestTime) then %}
+  {% if (differenceToOwnBestTime ~= nil and (mapScore:getRank() ~= 1 or differenceToOwnBestTime ~= differenceToBestTime)) then %}
+    {# It's not the previous 1st player that improved his score, show the difference #}
+
     {* colors.newBestTimeString *}
     Improved by
     <whitespace>
@@ -24,7 +26,7 @@
       {
         colors = colors,
         timeFormatter = timeFormatter,
-        differenceInMilliseconds = differenceToOwnBestTime
+        differenceInMilliseconds = differenceToOwnBestTime * -1
       }
     ]}
 

--- a/src/wesenGemaMod/GemaScoreManager/ScoreAttemptScoreOutput.lua
+++ b/src/wesenGemaMod/GemaScoreManager/ScoreAttemptScoreOutput.lua
@@ -170,9 +170,6 @@ function ScoreAttemptScoreOutput:outputMapScore(_mapScore, _previousMapScore, _i
     local bestMapScore = self:findBestMapScore(_mapScore, _previousMapScore, mainMapTop)
     if (bestMapScore) then
       differenceToFirstRank = _mapScore:getMilliseconds() - bestMapScore:getMilliseconds()
-      if (_mapScore:getRank() == 1) then
-        differenceToFirstRank = differenceToFirstRank * -1
-      end
     end
 
   end


### PR DESCRIPTION
Tested:

| scenario                                        | score difference shown |
|-------------------------------------------------|------------------------|
| first map score                                 | :x:                    |
| 1st place improves score                        | :x:                    |
| 2nd place improves but is still slower than 1st | :heavy_check_mark:     |
| 2nd place improves but ties 1st                 | :heavy_check_mark:     |
| 2nd place improves and beats 1st                | :heavy_check_mark:     |
| slower than own best time                       | :heavy_check_mark:     |
| difference to 1st place halved                  | :heavy_check_mark:     |

![Bildschirmfoto_2021-03-06_12-20-51](https://user-images.githubusercontent.com/15333605/110205047-a4241180-7e76-11eb-8c47-8eab3a0a9900.png)